### PR TITLE
Fix: Ensure products display on home and product pages correctly

### DIFF
--- a/css/products.css
+++ b/css/products.css
@@ -56,27 +56,34 @@
 /* Product Listing specific to products.html */
 #product-listing {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); /* Responsive grid, kept from original product styles */
-    gap: 20px; /* Kept from original product styles, var(--space-lg) from style.css is 22px, this is 20px */
-    margin-top: 20px; /* Add some space above the product listing */
+    /* Aligned with #deals-container from style.css */
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr));
+    gap: var(--space-lg); /* Assuming --space-lg is globally available from style.css */
+    margin-top: 20px; /* Add some space above the product listing, can be var(--space-lg) too if desired */
 }
 
-/* Styles for product-specific meta information if needed,
-   assuming .deal-card from style.css handles the main card layout.
-   These styles target the <p class="product-meta-info"> elements. */
-.deal-card .product-meta-info { /* Targetting the new class within a .deal-card */
-    font-size: 0.9em; /* From original .product-category, .product-farmer */
-    color: #555; /* From original .product-category, .product-farmer */
-    margin-bottom: 8px; /* Adjusted slightly from 5px for better spacing if needed */
+/* Styling for the new .product-category-display class */
+/* Aiming for consistency with .business-name or .best-before from style.css */
+.deal-card .product-category-display {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm, 8px); /* Use CSS variable from style.css, fallback to 8px */
+    font-size: 0.85em; /* Consistent with .business-name */
+    color: var(--neutral-medium, #566573); /* Consistent with .business-name, fallback color */
+    margin-bottom: var(--space-sm, 8px); /* Consistent with .business-name */
 }
 
-.deal-card .product-meta-info span { /* Targetting spans within the new class */
-    font-weight: normal; /* From original .product-category span, .product-farmer span */
-    color: #333; /* From original .product-category span, .product-farmer span */
-    /* Consider adding a class to the span if more specific styling is needed, e.g. <span class="meta-value"> */
+.deal-card .product-category-display i.fa-tag { /* Style for the icon specifically */
+    color: var(--primary-green, #27AE60); /* Use a theme color, fallback */
+    font-size: 1em; /* Adjust icon size if needed relative to text */
 }
+
 
 /*
+   The .product-meta-info rules have been REMOVED as this class is no longer used.
+   Farmer info now uses .business-name (styled globally in style.css).
+   Category info uses .product-category-display (styled above).
+
    The following styles from the old .product-card structure are now REMOVED,
    as .deal-card and its sub-element styles from style.css should cover them:
    - .product-card (background, border, padding, shadow, etc.)

--- a/js/app.js
+++ b/js/app.js
@@ -232,18 +232,18 @@ function renderProducts(productsToRender, containerElement) {
     }
 
     productsToRender.forEach(product => {
-        const card = document.createElement('div'); // Changed from article to div
-        card.classList.add('deal-card'); // Changed class to 'deal-card' for consistency
-        // card.classList.add('product-page-card'); // Optional: for product-specific tweaks via CSS later
+        const card = document.createElement('div');
+        card.classList.add('deal-card');
+        // card.classList.add('product-page-card');
 
         // Image container and image
         const imageContainer = document.createElement('div');
         imageContainer.classList.add('deal-card-image-container');
         const image = document.createElement('img');
-        image.src = product.imageUrl || 'images/placeholders/default.svg'; // Fallback image
+        image.src = product.imageUrl || 'images/placeholders/default.svg';
         image.alt = product.name;
-        // No specific class needed for img if deal-card-image-container styles cover it in style.css
-        // image.classList.add('product-image');
+        image.loading = 'lazy'; // Added loading lazy
+        image.onerror = function() { this.onerror=null; this.src='images/placeholders/default.svg'; this.alt='Placeholder image'; }; // Added onerror
         imageContainer.appendChild(image);
 
         // Content container
@@ -251,38 +251,47 @@ function renderProducts(productsToRender, containerElement) {
         contentContainer.classList.add('deal-card-content');
 
         const nameHeading = document.createElement('h3');
-        // No specific class needed if deal-card h3 style is sufficient
-        // nameHeading.classList.add('product-name');
         nameHeading.textContent = product.name;
 
         // Price container and price (mimicking deal card structure)
         const priceContainer = document.createElement('div');
         priceContainer.classList.add('price-container');
         const priceSpan = document.createElement('span');
-        priceSpan.classList.add('price'); // Use 'price' class like in deal-card
-        priceSpan.textContent = `$${parseFloat(product.price).toFixed(2)}`;
+        priceSpan.classList.add('price');
+        priceSpan.textContent = `R${parseFloat(product.price).toFixed(2)}`; // Changed $ to R
         priceContainer.appendChild(priceSpan);
         // Products don't have originalPrice in the provided data structure, so we omit it
 
-        const categoryPara = document.createElement('p');
-        categoryPara.classList.add('product-meta-info'); // A generic class for meta items
-        categoryPara.innerHTML = `Category: <span>${product.category}</span>`;
-
+        // Farmer (displayed like business-name)
         const farmerPara = document.createElement('p');
-        farmerPara.classList.add('product-meta-info'); // A generic class for meta items
-        farmerPara.innerHTML = `Sold by: <span>${product.farmer}</span>`;
+        farmerPara.classList.add('business-name'); // Use 'business-name' class for similar styling
+        farmerPara.title = product.farmer; // Tooltip for full name if needed
+        farmerPara.innerHTML = `<i class="fas fa-store-alt" aria-hidden="true"></i> ${product.farmer}`;
+
+        // Category (displayed with an icon, using a new class for styling)
+        const categoryPara = document.createElement('p');
+        categoryPara.classList.add('product-category-display'); // New class for specific styling
+        categoryPara.innerHTML = `<i class="fas fa-tag" aria-hidden="true"></i> Category: ${product.category}`;
 
         const descriptionPara = document.createElement('p');
-        descriptionPara.classList.add('description'); // Use 'description' class like in deal-card
+        descriptionPara.classList.add('description');
         descriptionPara.textContent = product.description;
+
+        // View Product Button (mimicking view-deal-btn)
+        const viewProductBtn = document.createElement('button');
+        viewProductBtn.classList.add('view-deal-btn'); // Use same class for styling
+        viewProductBtn.textContent = 'View Product';
+        // Optional: Add dataset for product ID and aria-label if it were functional
+        // viewProductBtn.dataset.productId = product.id;
+        // viewProductBtn.setAttribute('aria-label', `View details for ${product.name}`);
 
         // Assemble content
         contentContainer.appendChild(nameHeading);
-        contentContainer.appendChild(priceContainer); // Add price container
-        contentContainer.appendChild(categoryPara);
-        contentContainer.appendChild(farmerPara);
+        contentContainer.appendChild(priceContainer);
+        contentContainer.appendChild(farmerPara); // Changed from generic p to styled farmerPara
+        contentContainer.appendChild(categoryPara); // Changed from generic p to styled categoryPara
         contentContainer.appendChild(descriptionPara);
-        // No "View Deal" button for products as per original structure
+        contentContainer.appendChild(viewProductBtn); // Added button
 
         // Assemble card
         card.appendChild(imageContainer);


### PR DESCRIPTION
This commit addresses two primary issues:
1. Products/deals not appearing on the home page.
2. The product page having a "broken" appearance.

Changes made:
- Modified `js/app.js` to initialize and render deals from `data/deals.json` on the home page (`index.html`) using the existing `js/ui.js` and `js/deals.js` modules. This ensures the home page now correctly displays available deals.
- Updated the `renderProducts` function in `js/app.js` and associated CSS in `css/products.css` for the product page (`products.html`). Product cards now use a structure and styling consistent with the deal cards on the home page, leveraging global styles from `style.css`. This resolves the "broken" look and ensures visual consistency across the site.

Both pages are now expected to display their respective items correctly, and existing filtering functionalities remain intact.