### PR TITLE
Fix: Prevent page navigation on "View Deal" button click

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -152,6 +152,7 @@ function attachViewDealListeners() {
 }
 
 function handleViewDealButtonClick(event) {
+    event.preventDefault(); // Add this line
     const dealId = event.currentTarget.dataset.dealId;
     if (dealId && viewDealHandler) { // viewDealHandler is the callback from app.js
         viewDealHandler(dealId, event.currentTarget); // Pass the button element


### PR DESCRIPTION
I've added `event.preventDefault()` to the `handleViewDealButtonClick` event handler in `js/ui.js`.

This change ensures that clicking the "View Deal" button consistently opens the deal detail modal without triggering any unintended page navigation, addressing the behavior you reported. The buttons are `<button>` elements, but this provides an additional layer of robustness to the event handling.