### PR TITLE
Fix: Ensure modal window appears on "View Deal" click

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -143,9 +143,9 @@ async function handleViewDeal(dealId, buttonElement) {
         // Simulate a short delay to ensure spinner is visible
         await new Promise(resolve => setTimeout(resolve, 150));
 
-        const deal = getDealById(dealId);
-        if (deal) {
-            populateModalWithDeal(deal);
+        const deal = getDealById(dealId); // We still need the deal object for the 'if (deal)' check
+        if (deal) { // Check if the deal object exists
+            populateModalWithDeal(dealId); // <--- CHANGE THIS LINE to pass dealId
             openModal();
         } else {
             console.warn(`Deal with ID ${dealId} not found.`);


### PR DESCRIPTION
Corrected an issue where the deal detail modal was not appearing after clicking the "View Deal" button.

The bug was caused by an argument mismatch: `js/app.js` was calling `populateModalWithDeal(dealObject)` while the function in `js/modal.js` expected `populateModalWithDeal(dealId)`.

This commit updates `js/app.js` to correctly pass the `dealId` to `populateModalWithDeal`. This ensures that the modal module can fetch the deal data using the ID and then populate and display the modal as intended.