### PR TITLE
Feat: Enhance modal visuals and fix image display

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
             <button class="modal-close" aria-label="Close modal" data-micromodal-close><i class="fas fa-times"></i></button>
             <div class="modal-body">
                 <div class="modal-image-container">
-                    <img id="modalImage" src="images/placeholder-food.png" alt="Deal product image" loading="lazy"> 
+                    <img id="modalImage" src="images/placeholders/default.svg" alt="Deal product image">
                 </div>
                 <div class="modal-details">
                     <h3 id="modalTitle">Deal Title</h3>

--- a/style.css
+++ b/style.css
@@ -984,6 +984,7 @@ a:focus-visible {
     overflow: hidden;
     margin-bottom: 0; /* Remove bottom margin, rely on gap */
     border: 1px solid var(--border-color);
+    background-color: var(--neutral-lightest);
 }
 .modal-image-container img { width: 100%; height: 100%; object-fit: contain; } /* Use contain for modal */
 .modal-details h3 {
@@ -994,8 +995,27 @@ a:focus-visible {
     margin-bottom: var(--space-sm);
 }
 .modal-business { font-size: 0.95em; }
-.modal-price { font-size: 1.9em; }
-.modal-best-before { font-size: 0.9em; }
+.modal-price {
+    font-size: 1.9em;
+    color: var(--primary-green);
+    font-weight: 700;
+}
+.modal-best-before {
+    font-size: 0.9em;
+    color: var(--accent-orange);
+    font-weight: 700;
+}
+.modal-best-before i {
+    color: var(--accent-orange);
+}
+
+.modal-original-price {
+    font-size: 0.9em; /* Slightly smaller than the main modal price */
+    text-decoration: line-through;
+    color: var(--neutral-light);
+    margin-left: var(--space-sm); /* Add some space if it's next to the current price */
+}
+
 .modal-description-text { /* Target specific class */
     font-size: 1em;
     line-height: 1.7;


### PR DESCRIPTION
This commit implements several visual improvements to the deal detail modal based on your feedback:

1.  **Fix Modal Image Display:**
    - Removed `loading="lazy"` from the modal's `<img>` tag in `index.html` to prevent potential issues with initially hidden elements.
    - Set a valid initial `src` attribute for the modal image in `index.html` to `images/placeholders/default.svg`.

2.  **Style Original Price:**
    - Added CSS to `style.css` for `.modal-original-price` to apply a `text-decoration: line-through`, set its color to `var(--neutral-light)`, reduce font size slightly, and add a left margin for better separation.

3.  **Enhance Key Information Display:**
    - Modified `.modal-price` CSS to use `var(--primary-green)` for color and `font-weight: 700` for emphasis.
    - Updated `.modal-best-before` CSS to use `var(--accent-orange)` for color (including its icon) and `font-weight: 700` to make it more prominent.
    - Added `background-color: var(--neutral-lightest)` to `.modal-image-container` to provide a better visual frame for images, especially those with transparency or that don't fill the container.

These changes aim to improve the clarity, visual appeal, and consistency of the deal modal.