### PR TITLE
fix: Correct title styling and spacing on products page

### DIFF
--- a/css/products.css
+++ b/css/products.css
@@ -1,5 +1,15 @@
 /* Styles for products.html - Product Listing Page */
 
+.page-title-container {
+    padding-top: var(--space-lg);
+    padding-bottom: var(--space-lg); /* Or margin-bottom */
+    text-align: center; /* Optional: if title should be centered */
+}
+/* Ensure h2 inside this container has appropriate margins if needed, */
+/* or rely on global h2 styling. Global h2 has margin-bottom: var(--space-md); */
+/* which should be fine. */
+
+
 /* Filters and Sort section specific to products.html */
 .filters-sort-section {
     background-color: var(--bg-page);

--- a/products.html
+++ b/products.html
@@ -33,10 +33,13 @@
         </div>
     </header>
     <main>
-        <h1>Our Products</h1>
-        <div class="products-layout-container">
-            <aside class="filters-sort-section">
-                <h2>Filters</h2>
+        <div class="container page-title-container">
+            <h2>Our Products</h2>
+        </div>
+        <div class="container">
+            <div class="products-layout-container">
+                <aside class="filters-sort-section">
+                    <h2>Filters</h2>
                 <div>
                     <label for="category-filter">Filter by Category:</label>
                     <select id="category-filter" name="category">
@@ -89,6 +92,7 @@
                     <h2>Store Locations</h2>
                     <div id="map-view" style="height: 400px; margin-bottom: 20px;"></div>
                 </section>
+            </div>
             </div>
         </div>
     </main>


### PR DESCRIPTION
This commit addresses your feedback regarding the styling and layout of the products page (`products.html`).

Key corrections include:

1.  **Page Title Alignment and Styling:**
    *   The "Our Products" page title has been changed from `<h1>` to `<h2>` for semantic consistency with other content pages.
    *   The title is now wrapped in a `<div class="container page-title-container">`, which, along with new CSS in `css/products.css`, ensures:
        *   The title is properly centered on the page.
        *   Adequate vertical padding (`padding-top` and `padding-bottom`) is applied around the title.
        *   The title inherits global `<h2>` styles for consistent font appearance.
    *   This resolves issues where the title was misaligned, too far left, and nearly cut off.

2.  **Consistent Page Width and Horizontal Spacing:**
    *   The main content layout of `products.html` (the `div.products-layout-container` containing filters, product listings, and map) is now wrapped in a standard `<div class="container">`.
    *   This ensures that the entire products section adheres to the site's global maximum width and horizontal padding rules, providing a more consistent look and feel with other pages and preventing content from stretching excessively on wide screens or being too close to edges on mobile.

These adjustments improve the visual presentation, consistency, and responsiveness of the `products.html` page, directly addressing the reported concerns.