### PR TITLE
Fix: Improve product page header and font rendering

### DIFF
--- a/css/products.css
+++ b/css/products.css
@@ -142,3 +142,9 @@
         width: 100%;
     }
 }
+
+/* Adjust header padding for product pages to make it more compact */
+.site-header {
+    padding-top: var(--space-lg);
+    padding-bottom: var(--space-lg);
+}

--- a/products.html
+++ b/products.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/products.css">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <header class="site-header">

--- a/tests/products_page.test.js
+++ b/tests/products_page.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Product Page Specific Adjustments', () => {
+    let productsHtmlContent = '';
+    let productsCssContent = '';
+
+    beforeAll(() => {
+        // Resolve paths relative to the project root
+        // Assuming the script is run from the project root or tests/ directory
+        // Adjust path if necessary based on actual execution context of tests
+        const productsHtmlPath = path.resolve(__dirname, '../products.html');
+        const productsCssPath = path.resolve(__dirname, '../css/products.css');
+
+        try {
+            productsHtmlContent = fs.readFileSync(productsHtmlPath, 'utf8');
+        } catch (err) {
+            console.error('Error reading products.html for tests:', err);
+            // productsHtmlContent will remain empty, causing relevant test to fail
+        }
+
+        try {
+            productsCssContent = fs.readFileSync(productsCssPath, 'utf8');
+        } catch (err) {
+            console.error('Error reading css/products.css for tests:', err);
+            // productsCssContent will remain empty, causing relevant test to fail
+        }
+    });
+
+    test('products.html should include Google Fonts link', () => {
+        if (!productsHtmlContent) {
+            throw new Error('products.html content is not available for testing.');
+        }
+        expect(productsHtmlContent).toContain('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Poppins:wght@400;600;700&display=swap');
+    });
+
+    test('css/products.css should include .site-header padding override', () => {
+        if (!productsCssContent) {
+            throw new Error('css/products.css content is not available for testing.');
+        }
+        // Normalize whitespace and check for the rule.
+        // This makes the test less brittle to exact spacing.
+        const expectedCssRule = `
+   .site-header {
+       padding-top: var(--space-lg);
+       padding-bottom: var(--space-lg);
+   }
+        `.replace(/\s+/g, ' ').trim();
+        const actualCssContentNormalized = productsCssContent.replace(/\s+/g, ' ').trim();
+        expect(actualCssContentNormalized).toContain(expectedCssRule.substring(0, expectedCssRule.indexOf('{')).trim()); // Check for selector
+        expect(actualCssContentNormalized).toContain('padding-top: var(--space-lg);');
+        expect(actualCssContentNormalized).toContain('padding-bottom: var(--space-lg);');
+    });
+});


### PR DESCRIPTION
This commit addresses two issues on the product page:

1.  **Header Spacing:** Reduced top and bottom padding for the main site header on product pages (`products.html`) by adding an override in `css/products.css`. This provides a more compact header, giving more space to product content.

2.  **Skinny Fonts:** Corrected the "skinny font" issue by adding a Google Fonts `<link>` tag to `products.html`. This ensures that the 'Poppins' and 'Open Sans' fonts are loaded with the necessary weights (Poppins: 400, 600, 700; Open Sans: 400, 600), allowing proper `font-weight` styles to be applied.

Additionally, I added a new test file `tests/products_page.test.js` with tests to verify:
- The presence of the Google Fonts link in `products.html`.
- The CSS override for header padding in `css/products.css`.