### PR TITLE
Refine deal card visuals and information hierarchy

### DIFF
--- a/style.css
+++ b/style.css
@@ -430,16 +430,30 @@ a:focus-visible {
     font-size: 0.92em; /* Slightly smaller */
     margin-bottom: var(--space-sm); /* Less space */
 }
-.deal-card .business-name { color: var(--neutral-medium); }
+.deal-card .business-name {
+    color: var(--neutral-dark);
+    font-weight: 600;
+}
 .deal-card .business-name i { color: var(--primary-green); font-size: 1.1em; margin-right: var(--space-xs); }
-.deal-card .best-before { color: var(--accent-orange); font-weight: 700; }
+.deal-card .best-before {
+    color: var(--accent-orange);
+    font-weight: 700;
+    font-size: 0.95em;
+    margin-bottom: var(--space-md); /* Increased spacing before price */
+    background-color: #FFF5E6; /* Light orange background */
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--border-radius-sm);
+    display: inline-flex; /* Changed to inline-flex */
+    align-items: center; /* Retain for internal alignment */
+    gap: var(--space-sm); /* Retain for internal alignment */
+}
 .deal-card .best-before i { font-size: 1em; margin-right: var(--space-xs); }
 
 .deal-card .price-container {
     display: flex;
     align-items: baseline; /* Back to baseline alignment */
     margin-top: var(--space-xs); /* Add slight space above price */
-    margin-bottom: var(--space-md);
+    margin-bottom: var(--space-sm);
     gap: var(--space-sm);
 }
 .deal-card .price {
@@ -451,7 +465,7 @@ a:focus-visible {
 .deal-card .original-price {
     font-size: 0.95em;
     text-decoration: line-through;
-    color: var(--neutral-light);
+    color: var(--neutral-medium);
 }
 
 .deal-card .description {


### PR DESCRIPTION
This commit updates `style.css` to improve the visual presentation of deal cards.

Key changes include:
- Adjusted spacing and padding within deal cards for better visual balance.
- Improved text contrast for elements like the original price and store name.
- Enhanced the prominence of the "best before" date by:
    - Increasing font size slightly.
    - Adding a subtle background color.
    - Ensuring proper alignment of its icon and text using `inline-flex`.
- Increased the visual weight of the store name.
- Ensured the original price is distinct but not distracting.

These changes aim to make deals more scannable, visually appealing, and easier for you to quickly understand key information.