### PR TITLE
feat: Add input validation for product reviews

### DIFF
--- a/middleware/validationMiddleware.js
+++ b/middleware/validationMiddleware.js
@@ -1,0 +1,11 @@
+const { validationResult } = require('express-validator');
+
+const validateRequest = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+};
+
+module.exports = { validateRequest };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "bcryptjs": "^3.0.2",
         "express": "^5.1.0",
+        "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.15.1",
         "puppeteer": "^24.10.0",
@@ -2337,6 +2338,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -3764,6 +3777,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -5246,6 +5264,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "bcryptjs": "^3.0.2",
     "express": "^5.1.0",
+    "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.15.1",
     "puppeteer": "^24.10.0",

--- a/routes/products.js
+++ b/routes/products.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const router = express.Router();
+const { body } = require('express-validator');
+const { validateRequest } = require('../middleware/validationMiddleware');
 const {
   getProducts,
   getProductById,
@@ -20,6 +22,16 @@ router.route('/:id').get(getProductById);
 // @route   POST /api/products/:id/reviews
 // @desc    Create a new review for a product
 // @access  Private
-router.route('/:id/reviews').post(authMiddleware, createProductReview); // Protected route
+router
+  .route('/:id/reviews')
+  .post(
+    authMiddleware, // Assuming this is the existing auth middleware
+    [ // Validation rules
+      body('rating', 'Rating must be a number').isNumeric(),
+      body('comment', 'Comment cannot be empty').not().isEmpty(),
+    ],
+    validateRequest, // Middleware to check for errors
+    createProductReview // Your controller
+  );
 
 module.exports = router;


### PR DESCRIPTION
Installed express-validator and implemented input validation for the 'create product review' endpoint.

- Added `express-validator` dependency.
- Created `middleware/validationMiddleware.js` with a `validateRequest` function to handle validation errors and return a 400 response if errors exist.
- Updated `routes/products.js` for the `POST /:id/reviews` route:
    - Added validation rules to ensure 'rating' is numeric and 'comment' is not empty.
    - Integrated the `validateRequest` middleware into the route chain.

This change enhances backend robustness by preventing invalid data from being processed for product reviews.